### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -1,4 +1,6 @@
 name: Pylint and Pytest
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/stephendade/aprilmav/security/code-scanning/1](https://github.com/stephendade/aprilmav/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only needs to read the repository contents (e.g., to check out code and run tests), we will set `contents: read`. This ensures that the workflow does not have unnecessary write permissions.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
